### PR TITLE
updated name according to typo in the generated binary name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cd go-wikitionary-parse
 wget https://dumps.wikimedia.org/enwiktionary/latest/enwiktionary-latest-pages-articles.xml.bz2
 bzip2 -d enwiktionary-latest-pages-articles.xml.bz2
 go install .
-go-wiktionary-parse -file enwiktionary-latest-pages-articles.xml -threads 20 -database test.db
+go-wikitionary-parse -file enwiktionary-latest-pages-articles.xml -threads 20 -database test.db
 ```
 
 


### PR DESCRIPTION
Took me long to realise that there is no $path misconfiguration or permission issue but a typo in the generated binary name which leads to command not found error. 